### PR TITLE
Fix bug when updating invoice items

### DIFF
--- a/app/models/bulk_discount.rb
+++ b/app/models/bulk_discount.rb
@@ -1,6 +1,7 @@
 class BulkDiscount < ApplicationRecord
   after_create :apply_discount
   after_update :apply_discount
+  after_destroy :update_discounts
 
   validates_presence_of :percentage_discount, numericality: true
   validates_presence_of :quantity_threshold
@@ -10,22 +11,42 @@ class BulkDiscount < ApplicationRecord
 
   def apply_discount
     invoice_items.clear
-    next_quantity_threshold = BulkDiscount.where('quantity_threshold > ?', quantity_threshold).minimum('quantity_threshold')
-    previous_quantity_threshold = BulkDiscount.where('quantity_threshold < ?', quantity_threshold).maximum('quantity_threshold')
-
-    if next_quantity_threshold.nil?
-      apply_full_upper_bounds
-    else
-      apply_upper_bounds(next_quantity_threshold)
-    end
-
-    if previous_quantity_threshold
-      apply_lower_bounds(previous_quantity_threshold)
-    end
+    check_all_discounts_above_this_discount_threshold
+    BulkDiscount.check_all_discounts_below quantity_threshold 
   end
 
   private
-  def apply_full_upper_bounds
+
+  def update_discounts
+    next_discount_threshold = BulkDiscount.next_quantity_threshold_from quantity_threshold
+    BulkDiscount.check_all_discounts_below(next_discount_threshold)
+  end
+
+  def check_all_discounts_above_this_discount_threshold
+    next_discount_threshold = BulkDiscount.next_quantity_threshold_from quantity_threshold
+    if next_discount_threshold
+      apply_to_all_up_to_the next_discount_threshold
+    else
+      apply_to_all_above_discount_threshold
+    end
+  end
+
+  def self.check_all_discounts_below(quantity_threshold)
+    previous_discount_threshold = BulkDiscount.previous_quantity_threshold_to quantity_threshold
+    if previous_discount_threshold
+      BulkDiscount.apply_to_all_discounts_below quantity_threshold, previous_discount_threshold
+    end
+  end
+
+  def self.next_quantity_threshold_from(quantity_threshold)
+    BulkDiscount.where('quantity_threshold > ?', quantity_threshold).minimum('quantity_threshold')
+  end
+
+  def self.previous_quantity_threshold_to(quantity_threshold)
+    BulkDiscount.where('quantity_threshold < ?', quantity_threshold).maximum('quantity_threshold')
+  end
+
+  def apply_to_all_above_discount_threshold
     applied = InvoiceItem.joins("INNER JOIN items ON invoice_items.item_id = items.id")
                          .joins("INNER JOIN merchants ON items.merchant_id = merchants.id")
                          .joins("INNER JOIN bulk_discounts ON bulk_discounts.merchant_id = merchants.id")
@@ -35,19 +56,19 @@ class BulkDiscount < ApplicationRecord
     invoice_items << applied
   end
 
-  def apply_upper_bounds(next_quantity_threshold)
+  def apply_to_all_up_to_the(next_quantity_threshold_from)
     applied = InvoiceItem.joins("INNER JOIN items ON invoice_items.item_id = items.id")
                          .joins("INNER JOIN merchants ON items.merchant_id = merchants.id")
                          .joins("INNER JOIN bulk_discounts ON bulk_discounts.merchant_id = merchants.id")
                          .joins("INNER JOIN invoices ON invoices.id = invoice_items.invoice_id")
                          .where(merchants: {id: merchant.id})
                          .where('invoice_items.quantity >= ?', quantity_threshold)
-                         .where('invoice_items.quantity < ?', next_quantity_threshold)
+                         .where('invoice_items.quantity < ?', next_quantity_threshold_from)
     invoice_items << applied
   end
 
-  def apply_lower_bounds(previous_quantity_threshold)
-    bulk_discount = BulkDiscount.where(bulk_discounts: {quantity_threshold: previous_quantity_threshold}).first
+  def self.apply_to_all_discounts_below(quantity_threshold, to_quantity_threshold)
+    bulk_discount = BulkDiscount.where(bulk_discounts: {quantity_threshold: to_quantity_threshold}).first
     
     applied = InvoiceItem.joins("INNER JOIN items ON invoice_items.item_id = items.id")
                          .joins("INNER JOIN merchants ON items.merchant_id = merchants.id")

--- a/spec/models/bulk_discount_spec.rb
+++ b/spec/models/bulk_discount_spec.rb
@@ -17,18 +17,62 @@ RSpec.describe BulkDiscount, type: :model do
     @item_3 = FactoryBot.create(:item, merchant: @merchant) 
     @item_4 = FactoryBot.create(:item, merchant: @merchant) 
     @item_5 = FactoryBot.create(:item, merchant: @merchant) 
+    @item_6 = FactoryBot.create(:item, merchant: @merchant) 
+    @item_7 = FactoryBot.create(:item, merchant: @merchant) 
     
     @customer_1 = FactoryBot.create(:customer)
     @invoice_1 = FactoryBot.create(:invoice, customer: @customer_1, status: 1)
     @invoice_item_1 = FactoryBot.create(:invoice_item, invoice: @invoice_1, item: @item_1, quantity: 1)
-    @invoice_item_2 = FactoryBot.create(:invoice_item, invoice: @invoice_1, item: @item_2, quantity: 5)
-    @invoice_item_3 = FactoryBot.create(:invoice_item, invoice: @invoice_1, item: @item_3, quantity: 9)
+    @invoice_item_2 = FactoryBot.create(:invoice_item, invoice: @invoice_1, item: @item_2, quantity: 2)
+    @invoice_item_3 = FactoryBot.create(:invoice_item, invoice: @invoice_1, item: @item_3, quantity: 5)
     @invoice_item_4 = FactoryBot.create(:invoice_item, invoice: @invoice_1, item: @item_4, quantity: 10)
     @invoice_item_5 = FactoryBot.create(:invoice_item, invoice: @invoice_1, item: @item_5, quantity: 15)
-    @invoice_items = [@invoice_item_1, @invoice_item_2, @invoice_item_3, @invoice_item_4, @invoice_item_5]
+    @invoice_item_6 = FactoryBot.create(:invoice_item, invoice: @invoice_1, item: @item_6, quantity: 20)
+    @invoice_item_7 = FactoryBot.create(:invoice_item, invoice: @invoice_1, item: @item_7, quantity: 25)
+
+    @invoice_items = [
+      @invoice_item_1, 
+      @invoice_item_2, 
+      @invoice_item_3, 
+      @invoice_item_4, 
+      @invoice_item_5,
+      @invoice_item_6,
+      @invoice_item_7
+    ]
   end
 
   describe 'instance method,' do
+    describe '#update_discounts' do
+      it 'removes the discount and updates invoice items that can have other discounts applied to it' do
+        discount_1 = FactoryBot.create(:bulk_discount, merchant: @merchant, quantity_threshold: 2)
+        discount_2 = FactoryBot.create(:bulk_discount, merchant: @merchant, quantity_threshold: 10)
+        discount_3 = FactoryBot.create(:bulk_discount, merchant: @merchant, quantity_threshold: 20)
+
+        @invoice_items.each(&:reload)
+
+        expect(@invoice_item_1.bulk_discount_id).to eq nil
+        expect(@invoice_item_2.bulk_discount_id).to eq discount_1.id
+        expect(@invoice_item_3.bulk_discount_id).to eq discount_1.id
+        expect(@invoice_item_4.bulk_discount_id).to eq discount_2.id
+        expect(@invoice_item_5.bulk_discount_id).to eq discount_2.id
+        expect(@invoice_item_6.bulk_discount_id).to eq discount_3.id
+        expect(@invoice_item_7.bulk_discount_id).to eq discount_3.id
+
+
+        discount_2.destroy
+
+        @invoice_items.each(&:reload)
+
+        expect(@invoice_item_1.bulk_discount_id).to eq nil
+        expect(@invoice_item_2.bulk_discount_id).to eq discount_1.id
+        expect(@invoice_item_3.bulk_discount_id).to eq discount_1.id
+        expect(@invoice_item_4.bulk_discount_id).to eq discount_1.id
+        expect(@invoice_item_5.bulk_discount_id).to eq discount_1.id
+        expect(@invoice_item_6.bulk_discount_id).to eq discount_3.id
+        expect(@invoice_item_7.bulk_discount_id).to eq discount_3.id
+      end
+    end
+    
     describe '#apply_discount' do
       it 'only applies this discount if the invoice status is in progress' do
         discount = FactoryBot.create(:bulk_discount, merchant: @merchant, quantity_threshold: 1)
@@ -39,28 +83,34 @@ RSpec.describe BulkDiscount, type: :model do
         expect(@invoice_item_3.bulk_discount_id).to eq discount.id
         expect(@invoice_item_4.bulk_discount_id).to eq discount.id
         expect(@invoice_item_5.bulk_discount_id).to eq discount.id
+        expect(@invoice_item_6.bulk_discount_id).to eq discount.id
+        expect(@invoice_item_7.bulk_discount_id).to eq discount.id
       end
       
       it 'applies only to invoice item quantities in range of another discount' do
         discount_1 = FactoryBot.create(:bulk_discount, merchant: @merchant, quantity_threshold: 5)
-
+        
         @invoice_items.each(&:reload)
-
+        
         expect(@invoice_item_1.bulk_discount_id).to eq nil
-        expect(@invoice_item_2.bulk_discount_id).to eq discount_1.id
+        expect(@invoice_item_2.bulk_discount_id).to eq nil
         expect(@invoice_item_3.bulk_discount_id).to eq discount_1.id
         expect(@invoice_item_4.bulk_discount_id).to eq discount_1.id
         expect(@invoice_item_5.bulk_discount_id).to eq discount_1.id
+        expect(@invoice_item_6.bulk_discount_id).to eq discount_1.id
+        expect(@invoice_item_7.bulk_discount_id).to eq discount_1.id
 
         discount_2 = FactoryBot.create(:bulk_discount, merchant: @merchant, quantity_threshold: 10)
 
         @invoice_items.each(&:reload)
 
         expect(@invoice_item_1.bulk_discount_id).to eq nil
-        expect(@invoice_item_2.bulk_discount_id).to eq discount_1.id
+        expect(@invoice_item_2.bulk_discount_id).to eq nil
         expect(@invoice_item_3.bulk_discount_id).to eq discount_1.id
         expect(@invoice_item_4.bulk_discount_id).to eq discount_2.id
         expect(@invoice_item_5.bulk_discount_id).to eq discount_2.id
+        expect(@invoice_item_6.bulk_discount_id).to eq discount_2.id
+        expect(@invoice_item_7.bulk_discount_id).to eq discount_2.id
         
         discount_2.quantity_threshold = 11
         discount_2.save
@@ -68,10 +118,12 @@ RSpec.describe BulkDiscount, type: :model do
         @invoice_items.each(&:reload)
         
         expect(@invoice_item_1.bulk_discount_id).to eq nil
-        expect(@invoice_item_2.bulk_discount_id).to eq discount_1.id
+        expect(@invoice_item_2.bulk_discount_id).to eq nil
         expect(@invoice_item_3.bulk_discount_id).to eq discount_1.id
         expect(@invoice_item_4.bulk_discount_id).to eq discount_1.id
         expect(@invoice_item_5.bulk_discount_id).to eq discount_2.id
+        expect(@invoice_item_6.bulk_discount_id).to eq discount_2.id
+        expect(@invoice_item_7.bulk_discount_id).to eq discount_2.id
 
         discount_1.percentage_discount = 15
         discount_1.save
@@ -79,10 +131,12 @@ RSpec.describe BulkDiscount, type: :model do
         @invoice_items.each(&:reload)
         
         expect(@invoice_item_1.bulk_discount_id).to eq nil
-        expect(@invoice_item_2.bulk_discount_id).to eq discount_1.id
+        expect(@invoice_item_2.bulk_discount_id).to eq nil
         expect(@invoice_item_3.bulk_discount_id).to eq discount_1.id
         expect(@invoice_item_4.bulk_discount_id).to eq discount_1.id
         expect(@invoice_item_5.bulk_discount_id).to eq discount_2.id
+        expect(@invoice_item_6.bulk_discount_id).to eq discount_2.id
+        expect(@invoice_item_7.bulk_discount_id).to eq discount_2.id
         
       end
     end


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Please describe the problem you are trying to solve.

When a discount is deleted the application wasn't updating invoice items properly. The invoice items that were attached to the discount remained without a discount even though other discounts could technically be applied.

**Describe the solution you'd like**
Please describe the desired behavior.

After any discount that is deleted, other possible discounts should be applied to invoice items that are no longer related to the deleted discount.


- [x] Tests are passing 100%
- [x] Model Test Coverage 100%
- [x] Feature Test Coverage at least 95%

